### PR TITLE
Fix custom scatter return and clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,36 @@
 # djctools
 
-`djctools` streamlines logging, loss handling and multi-GPU training for PyTorch models. It integrates with [Weights & Biases](https://wandb.ai/) and keeps models JIT compatible even with complex, nested structures.
+`djctools` is a Python package designed to simplify logging, loss management, and multi-GPU training for deep learning models with complex, nested structures. It integrates seamlessly with PyTorch and [Weights & Biases (wandb)](https://wandb.ai/).
 
-## Features
+Key features:
 
-- **Singleton `wandb_wrapper`** – buffered metric logging with optional API key loading.
-- **`LoggingModule`** – drop-in base class that lets any submodule log metrics and toggle logging on or off.
-- **`LossModule`** – modular loss computation with helpers to sum or clear losses across a model.
-- **`PlottingModule`** – optional base class for asynchronous plotting from within a model.
-- **`Trainer`** – minimal training loop supporting irregular data structures and manual multi-GPU batch distribution.
+- Fine-grained control over logging with `LoggingModule`.
+- Modular and toggleable loss calculation with `LossModule`.
+- Efficient multi-GPU training with `Trainer` that works with standard `DataLoader` objects and irregular data from custom loaders like `djcdata`.
+- JIT compatibility despite flexible in-model logging functionality.
 
-## Installation
+## General concept
 
-```bash
-pip install git+https://github.com/jkiesele/djctools
+To facilitate these features, the general concept is that the loss functions and metrics calculations are part of the main model (inheriting from `torch.nn.Module`).
+For example, the model could be passed the truth targets in addition to the features in training and validation mode. The `Trainer`
+expects each batch to be a tuple or list of `(features, targets)` and forwards it unchanged to the model:
 ```
-
-Dependencies: `torch>=1.8.0`, `wandb>=0.12.0`, and `numpy`. The `djcdata` package is optional and can be installed separately.
+m = MyModel()
+out = m([features, targets])
+```
+However, if all included `LossModule` and `LoggingModule` instances are turned off for pure inference mode without any truth information, the call would become:
+```
+out = m([features, None])
+```
+This concept allows for generic training loops, transparent GPU parallelism, and fine grained control over the logging and loss modules.
+The details on how this is implemented and should be used can be found below.
 
 ## Quick example
 
 ```python
 import torch
-from djctools.module_extensions import LossModule, sum_all_losses
+from djctools.module_extensions import LossModule
+from djctools.training import Trainer
 
 class MyLoss(LossModule):
     def compute_loss(self, pred, target):
@@ -30,45 +38,212 @@ class MyLoss(LossModule):
         self.log("mse", loss)
         return loss
 
-model = torch.nn.Module()
-model.loss = MyLoss(logging_active=True)
+class MyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layer = torch.nn.Linear(5, 5)
+        self.loss = MyLoss(logging_active=True)
 
-pred = torch.randn(10, 5)
-truth = torch.randn(10, 5)
-model.loss(pred, truth)
+    def forward(self, batch):
+        features, targets = batch  # tuple input
+        out = self.layer(features)
+        if targets is not None:
+            self.loss(out, targets)
+        return out
 
-# aggregate losses from all LossModule instances
-total_loss = sum_all_losses(model)
-```
-
-Training on multiple GPUs:
-
-```python
-from djctools.training import Trainer
-
+model = MyModel()
 optimizer = torch.optim.Adam(model.parameters())
-trainer = Trainer(model, optimizer, num_gpus=2)
+trainer = Trainer(model, optimizer, num_gpus=1)
+
+# each item from the loader should be (features, targets)
 trainer.train_loop(train_loader)
 ```
 
-## Component overview
 
-### `wandb_wrapper`
-A singleton helper that buffers metrics and only contacts wandb when `flush()` is called. It can load the API key from `~/private/wandb_api.sh`.
+## Detailed Features
 
-### `LoggingModule`
-Base class providing a `log` method and a `switch_logging` toggle. When logging is disabled the module becomes a no-op, keeping the model JIT friendly.
+- **Singleton wandb Wrapper**: Centralized, buffered logging for `wandb`.
+- **LoggingModule**: Integrates logging into PyTorch modules with toggleable logging functionality.
+- **LossModule**: Modular loss calculation with support for aggregation and toggling specific loss terms.
+- **Trainer**: Manual data parallelism, handling irregular data and enabling custom batch distribution for multi-GPU training.
+- **Compatibility with djcdata**: Supports custom data loaders, including `djcdata`, which outputs lists of dictionaries or tensors.
 
-### `LossModule`
-Extends `LoggingModule` with storage for computed losses and utilities such as `sum_all_losses` and `clear_all_losses`. Loss calculation can be disabled dynamically, allowing inference without truth information.
+---
 
-### `PlottingModule`
-Caches data during forward passes and spawns a thread to create plots when `flush()` is called.
+## Basic Usage Example with MNIST
 
-### `Trainer`
-Handles manual batch distribution across devices and works with both standard `DataLoader` objects and irregular structures like lists of dictionaries. See the `examples` directory for an MNIST training script.
+For the impatient, there is an example using the `Trainer` with a standard dataset like MNIST in the `examples` directory in this repository.
 
-## License
 
-This project is licensed under the MIT License.
+## Installation
+
+```bash
+pip install git+https://github.com/jkiesele/djctools
+```
+
+### Dependencies
+
+- `torch>=1.8.0`
+- `wandb>=0.12.0`
+- `djcdata` (optional, will not be installed by default, see https://github.com/jkiesele/djcdata)
+
+---
+
+## wandb_wrapper
+
+`wandb_wrapper` is a singleton class that manages all `wandb` logging for the model. It buffers log metrics, provides a centralized control for logging activation, and initializes `wandb` with optional API key loading from `~/private/wandb_api.sh`.
+
+### Basic Usage
+
+```python
+from djctools.wandb_tools import wandb_wrapper
+
+# Initialize wandb
+wandb_wrapper.init(project="my_project")
+
+# Activate or deactivate logging
+wandb_wrapper.activate()
+wandb_wrapper.deactivate()
+
+# Log metrics
+wandb_wrapper.log("accuracy", 0.95)
+wandb_wrapper.log("loss", 0.1)
+
+# Flush buffered logs to wandb
+wandb_wrapper.flush()
+
+# Finish the wandb run
+wandb_wrapper.finish()
+```
+
+### API Key Loading
+
+If no API key is provided, `wandb_wrapper` will look for a file at `~/private/wandb_api.sh` containing:
+
+```bash
+WANDB_API_KEY="your_api_key_here"
+```
+
+This feature supports secure logging in interactive sessions without exposing sensitive information in code.
+
+---
+
+## LoggingModule
+
+`LoggingModule` is a subclass of `torch.nn.Module` with integrated logging. The `logging_active` attribute allows you to toggle logging for specific modules or entire model hierarchies.
+
+### Basic Usage
+
+```python
+from djctools.module_extensions import LoggingModule
+
+# Create a logging-enabled module
+module = LoggingModule(logging_active=True)
+module.log("example_metric", 123)  # Logs to wandb_wrapper
+
+# Disable logging for the module
+module.switch_logging(False)
+module.log("example_metric", 456)  # This will not be logged
+```
+
+### Automatic Name Assignment
+
+If no name is provided, `LoggingModule` automatically assigns unique names (`LoggingModule1`, `LoggingModule2`, etc.), which are used as metric prefixes for easy identification.
+
+### Nested Module Logging
+
+`LoggingModule` supports nested logging. Using `switch_logging`, you can toggle logging for all `LoggingModule` instances within a parent module.
+
+```python
+# Example model with nested LoggingModules
+class MyModel(torch.nn.Module):
+    def __init__(self):
+        super(MyModel, self).__init__()
+        self.layer1 = LoggingModule(logging_active=True)
+        self.layer2 = LoggingModule(logging_active=False)
+
+# Toggle logging for all LoggingModule instances
+model = MyModel()
+switch_all_logging(model, enable_logging=True)
+```
+
+---
+
+## LossModule
+
+`LossModule`, a subclass of `LoggingModule`, provides modular loss management by allowing each instance to store computed losses, which can be toggled with `loss_active`.
+
+### Basic Usage
+
+```python
+from djctools.module_extensions import LossModule
+
+# Define a custom loss by subclassing LossModule
+class MyCustomLoss(LossModule):
+    def compute_loss(self, predictions, targets):
+        '''
+        This function will only be called if loss is set to active. 
+        '''
+        loss = torch.nn.functional.mse_loss(predictions, targets)
+        self.log("mse_loss", loss)
+        return loss
+
+# Use the custom loss in a model
+model = torch.nn.Module()
+model.loss_layer = MyCustomLoss(logging_active=True, loss_active=True)
+
+# Forward pass with loss calculation
+predictions = torch.randn(10, 5)
+targets = torch.randn(10, 5)
+model.loss_layer(predictions, targets)
+```
+
+### Toggling Loss Calculation
+
+Enable or disable loss calculation with `switch_loss_calculation`:
+
+```python
+# Disable loss calculation
+model.loss_layer.switch_loss_calculation(False)
+assert not model.loss_layer.loss_active
+
+# Enable loss calculation
+model.loss_layer.switch_loss_calculation(True)
+assert model.loss_layer.loss_active
+```
+
+### Aggregating Losses
+
+`module_extensions` includes static methods to manage all logging and losses across instances in a model recursively:
+
+```python
+# Sum all losses across LossModule instances
+total_loss = sum_all_losses(model)
+
+# Clear losses after an optimization step
+clear_all_losses(model)
+
+switch_all_logging(model, False) #disables all logging
+
+switch_all_losses(model, False) #disables all losses
+```
+
+This is particularly interesting if a model should be prepared for pure inference mode, and should not depend on truth information anymore.
+If all logging and losses are turned off, and the model was configured to use truth information only in logging or loss modules, then 
+the truth information fed to the model can be None.
+
+---
+
+## Trainer
+
+The `Trainer` class enables manual data parallelism, distributing computations across multiple GPUs while handling irregular data from custom data loaders, like `djcdata`.
+
+### Key Features
+
+- **Manual Data Parallelism**: Distributes data across multiple GPUs with explicit control over batch distribution.
+- **Custom Data Handling**: Compatible with data loaders like `djcdata`, which return lists of dictionaries or tensors.
+- **Gradient Averaging**: Averages gradients across GPUs before the optimization step.
+- **Model Synchronization**: Syncs model weights across GPUs after updates.
+
+The trainer assumes that each batch is a `(features, targets)` tuple and that the model's forward method accepts the same structure. After each forward pass it aggregates losses from all `LossModule` instances and clears them, so logging and loss handling remain synchronized.
 

--- a/README.md
+++ b/README.md
@@ -1,42 +1,14 @@
 # djctools
 
-`djctools` is a Python package designed to simplify logging, loss management, and multi-GPU training for deep learning models with complex, nested structures. It includes components that integrate seamlessly with PyTorch and [Weights & Biases (wandb)](https://wandb.ai/), providing tools for:
+`djctools` streamlines logging, loss handling and multi-GPU training for PyTorch models. It integrates with [Weights & Biases](https://wandb.ai/) and keeps models JIT compatible even with complex, nested structures.
 
-- Fine-grained control over logging with `LoggingModule`.
-- Modular and toggleable loss calculation with `LossModule`.
-- Efficient multi-GPU training with `Trainer`, can be used with standard torch `DataLoader` instances, and is additionally optimized for use with irregular data and custom data loaders like from `djcdata`.
-- jit-compatibility despite flexible in-model logging functionality.
+## Features
 
-## General concept
-
-To facilitate these features, the general concept is that the loss functions and metrics calculations are part of the main model (inheriting from `torch.nn.Module`).
-For example, the model could be passed the truth targets in addition to the features in training and validation mode:
-```
-m = MyModel()
-out = m([features, targets])
-```
-However, if all included `LossModule` and `LoggingModule` instances are turned off for pure inference mode without any truth information, the call would become:
-```
-out = m([features, None])
-```
-This concept allows for generic training loops, transparent GPU parallelism, and fine grained control over the logging and loss modules.
-The details on how this is implemented and should be used can be found below.
-
-
-## Detailed Features
-
-- **Singleton wandb Wrapper**: Centralized, buffered logging for `wandb`.
-- **LoggingModule**: Integrates logging into PyTorch modules with toggleable logging functionality.
-- **LossModule**: Modular loss calculation with support for aggregation and toggling specific loss terms.
-- **Trainer**: Manual data parallelism, handling irregular data and enabling custom batch distribution for multi-GPU training.
-- **Compatibility with djcdata**: Supports custom data loaders, including `djcdata`, which outputs lists of dictionaries or tensors.
-
----
-
-## Basic Usage Example with MNIST
-
-For the impatient, there is an example using the `Trainer` with a standard dataset like MNIST in the `examples` directory in this repository.
-
+- **Singleton `wandb_wrapper`** – buffered metric logging with optional API key loading.
+- **`LoggingModule`** – drop-in base class that lets any submodule log metrics and toggle logging on or off.
+- **`LossModule`** – modular loss computation with helpers to sum or clear losses across a model.
+- **`PlottingModule`** – optional base class for asynchronous plotting from within a model.
+- **`Trainer`** – minimal training loop supporting irregular data structures and manual multi-GPU batch distribution.
 
 ## Installation
 
@@ -44,167 +16,59 @@ For the impatient, there is an example using the `Trainer` with a standard datas
 pip install git+https://github.com/jkiesele/djctools
 ```
 
-### Dependencies
+Dependencies: `torch>=1.8.0`, `wandb>=0.12.0`, and `numpy`. The `djcdata` package is optional and can be installed separately.
 
-- `torch>=1.8.0`
-- `wandb>=0.12.0`
-- `djcdata` (optional, will not be installed by default, see https://github.com/jkiesele/djcdata)
-
----
-
-## wandb_wrapper
-
-`wandb_wrapper` is a singleton class that manages all `wandb` logging for the model. It buffers log metrics, provides a centralized control for logging activation, and initializes `wandb` with optional API key loading from `~/private/wandb_api.sh`.
-
-### Basic Usage
+## Quick example
 
 ```python
-from djctools.wandb_tools import wandb_wrapper
+import torch
+from djctools.module_extensions import LossModule, sum_all_losses
 
-# Initialize wandb
-wandb_wrapper.init(project="my_project")
-
-# Activate or deactivate logging
-wandb_wrapper.activate()
-wandb_wrapper.deactivate()
-
-# Log metrics
-wandb_wrapper.log("accuracy", 0.95)
-wandb_wrapper.log("loss", 0.1)
-
-# Flush buffered logs to wandb
-wandb_wrapper.flush()
-
-# Finish the wandb run
-wandb_wrapper.finish()
-```
-
-### API Key Loading
-
-If no API key is provided, `wandb_wrapper` will look for a file at `~/private/wandb_api.sh` containing:
-
-```bash
-WANDB_API_KEY="your_api_key_here"
-```
-
-This feature supports secure logging in interactive sessions without exposing sensitive information in code.
-
----
-
-## LoggingModule
-
-`LoggingModule` is a subclass of `torch.nn.Module` with integrated logging. The `logging_active` attribute allows you to toggle logging for specific modules or entire model hierarchies.
-
-### Basic Usage
-
-```python
-from djctools.module_extensions import LoggingModule
-
-# Create a logging-enabled module
-module = LoggingModule(logging_active=True)
-module.log("example_metric", 123)  # Logs to wandb_wrapper
-
-# Disable logging for the module
-module.switch_logging(False)
-module.log("example_metric", 456)  # This will not be logged
-```
-
-### Automatic Name Assignment
-
-If no name is provided, `LoggingModule` automatically assigns unique names (`LoggingModule1`, `LoggingModule2`, etc.), which are used as metric prefixes for easy identification.
-
-### Nested Module Logging
-
-`LoggingModule` supports nested logging. Using `switch_logging`, you can toggle logging for all `LoggingModule` instances within a parent module.
-
-```python
-# Example model with nested LoggingModules
-class MyModel(torch.nn.Module):
-    def __init__(self):
-        super(MyModel, self).__init__()
-        self.layer1 = LoggingModule(logging_active=True)
-        self.layer2 = LoggingModule(logging_active=False)
-
-# Toggle logging for all LoggingModule instances
-model = MyModel()
-switch_all_logging(model, enable_logging=True)
-```
-
----
-
-## LossModule
-
-`LossModule`, a subclass of `LoggingModule`, provides modular loss management by allowing each instance to store computed losses, which can be toggled with `loss_active`.
-
-### Basic Usage
-
-```python
-from djctools.module_extensions import LossModule
-
-# Define a custom loss by subclassing LossModule
-class MyCustomLoss(LossModule):
-    def compute_loss(self, predictions, targets):
-        '''
-        This function will only be called if loss is set to active. 
-        '''
-        loss = torch.nn.functional.mse_loss(predictions, targets)
-        self.log("mse_loss", loss)
+class MyLoss(LossModule):
+    def compute_loss(self, pred, target):
+        loss = torch.nn.functional.mse_loss(pred, target)
+        self.log("mse", loss)
         return loss
 
-# Use the custom loss in a model
 model = torch.nn.Module()
-model.loss_layer = MyCustomLoss(logging_active=True, loss_active=True)
+model.loss = MyLoss(logging_active=True)
 
-# Forward pass with loss calculation
-predictions = torch.randn(10, 5)
-targets = torch.randn(10, 5)
-model.loss_layer(predictions, targets)
-```
+pred = torch.randn(10, 5)
+truth = torch.randn(10, 5)
+model.loss(pred, truth)
 
-### Toggling Loss Calculation
-
-Enable or disable loss calculation with `switch_loss_calculation`:
-
-```python
-# Disable loss calculation
-model.loss_layer.switch_loss_calculation(False)
-assert not model.loss_layer.loss_active
-
-# Enable loss calculation
-model.loss_layer.switch_loss_calculation(True)
-assert model.loss_layer.loss_active
-```
-
-### Aggregating Losses
-
-`module_extensions` includes static methods to manage all logging and losses across instances in a model recursively:
-
-```python
-# Sum all losses across LossModule instances
+# aggregate losses from all LossModule instances
 total_loss = sum_all_losses(model)
-
-# Clear losses after an optimization step
-clear_all_losses(model)
-
-switch_all_logging(model, False) #disables all logging
-
-switch_all_losses(model, False) #disables all losses
 ```
 
-This is particularly interesting if a model should be prepared for pure inference mode, and should not depend on truth information anymore.
-If all logging and losses are turned off, and the model was configured to use truth information only in logging or loss modules, then 
-the truth information fed to the model can be None.
+Training on multiple GPUs:
 
----
+```python
+from djctools.training import Trainer
 
-## Trainer
+optimizer = torch.optim.Adam(model.parameters())
+trainer = Trainer(model, optimizer, num_gpus=2)
+trainer.train_loop(train_loader)
+```
 
-The `Trainer` class enables manual data parallelism, distributing computations across multiple GPUs while handling irregular data from custom data loaders, like `djcdata`.
+## Component overview
 
-### Key Features
+### `wandb_wrapper`
+A singleton helper that buffers metrics and only contacts wandb when `flush()` is called. It can load the API key from `~/private/wandb_api.sh`.
 
-- **Manual Data Parallelism**: Distributes data across multiple GPUs with explicit control over batch distribution.
-- **Custom Data Handling**: Compatible with data loaders like `djcdata`, which return lists of dictionaries or tensors.
-- **Gradient Averaging**: Averages gradients across GPUs before the optimization step.
-- **Model Synchronization**: Syncs model weights across GPUs after updates.
+### `LoggingModule`
+Base class providing a `log` method and a `switch_logging` toggle. When logging is disabled the module becomes a no-op, keeping the model JIT friendly.
+
+### `LossModule`
+Extends `LoggingModule` with storage for computed losses and utilities such as `sum_all_losses` and `clear_all_losses`. Loss calculation can be disabled dynamically, allowing inference without truth information.
+
+### `PlottingModule`
+Caches data during forward passes and spawns a thread to create plots when `flush()` is called.
+
+### `Trainer`
+Handles manual batch distribution across devices and works with both standard `DataLoader` objects and irregular structures like lists of dictionaries. See the `examples` directory for an MNIST training script.
+
+## License
+
+This project is licensed under the MIT License.
 

--- a/src/djctools/training.py
+++ b/src/djctools/training.py
@@ -41,13 +41,13 @@ class _CustomDataParallel(DataParallel):
 
         for i, device_id in enumerate(device_ids):
             # Create device-specific slices of the input.
-            device_input = [ inputs[0][i] ] #wrap in one extra list as in apply_parallel the list is unpacked for some reason, so to mitigate this, we have to wrap it in another list
-            device_kwargs = kwargs
-            
-            scattered_inputs.append(device_input)  # Convert to tuple if needed by forward.
+            device_input = (inputs[0][i],)  # ensure each replica receives a tuple of inputs
+            device_kwargs = kwargs if kwargs is not None else {}
+
+            scattered_inputs.append(device_input)
             scattered_kwargs.append(device_kwargs)
-        
-        return scattered_inputs, tuple(scattered_kwargs)
+
+        return tuple(scattered_inputs), tuple(scattered_kwargs)
 
 
 

--- a/tests/test_wandb_wrapper.py
+++ b/tests/test_wandb_wrapper.py
@@ -38,7 +38,7 @@ class TestWandbWrapper(unittest.TestCase):
         wandb_wrapper.log("accuracy", 0.95)
         self.assertNotIn("accuracy", wandb_wrapper.log_buffer)
 
-    def no_test_flush_clears_log_buffer(self):
+    def test_flush_clears_log_buffer(self):
         """Test that flush clears the log buffer."""
         wandb_wrapper.log("accuracy", 0.95)
         wandb_wrapper.flush()


### PR DESCRIPTION
## Summary
- fix `_CustomDataParallel.scatter` to return tuples as expected by `DataParallel`
- ensure `wandb_wrapper.flush` test is executed
- rewrite README with feature overview and quick examples

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6892fe4e5de4832fa474e459c48ef21d