### PR TITLE
Fix race conditions in multi-GPU training

### DIFF
--- a/src/djctools/parallel.py
+++ b/src/djctools/parallel.py
@@ -146,6 +146,11 @@ def _infer_batch_size(x: Any) -> int:
 
 
 def local_worker(model: nn.Module, batch: Tuple[Any, Any], device: torch.device) -> LocalStepInfo:
+
+    # set device context explicitly to avoid multi-GPU race conditions
+    if device.type == 'cuda':
+        torch.cuda.set_device(device)
+    
     x, y = batch
 
     bs = _infer_batch_size(x)


### PR DESCRIPTION
Fix race conditions in multi-GPU training. Before, training on more than one GPU was failing with the following error:

```
Traceback (most recent call last):
  File "/work/abrusamolino/e2ereco/training/training_DICEfeat.py", line 228, in <module>
    main()
  File "/work/abrusamolino/e2ereco/training/training_DICEfeat.py", line 185, in main
    trainer.train_loop(train_loader) #training loop
  File "/usr/local/lib/python3.10/dist-packages/djctools/training.py", line 214, in train_loop
    info = train_step_threaded(self.model_replicas, self.optimizer, batches, self.devices, check_sync=False, has_cuda = has_cuda)
  File "/usr/local/lib/python3.10/dist-packages/djctools/parallel.py", line 272, in train_step_threaded
    infos = threaded_local_steps(replicas, batches, devices)
  File "/usr/local/lib/python3.10/dist-packages/djctools/parallel.py", line 186, in threaded_local_steps
    infos = [f.result() for f in futures]
  File "/usr/local/lib/python3.10/dist-packages/djctools/parallel.py", line 186, in <listcomp>
    infos = [f.result() for f in futures]
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 451, in result
    return self.__get_result()
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
  File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.10/dist-packages/djctools/parallel.py", line 156, in local_worker
    _ = model(batch)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1747, in _call_impl
    return forward_call(*args, **kwargs)
  File "/work/abrusamolino/e2ereco/models/model_DICEfeat.py", line 99, in forward
    output, neighbor_idx, distsq, space = block["gravnet"](output, row_splits, x_coords=x_coords)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1747, in _call_impl
    return forward_call(*args, **kwargs)
  File "/work/abrusamolino/e2ereco/modules/gravnet_init.py", line 123, in forward
    neighbor_idx, distsq = binned_select_knn(self.k, space, row_splits) #, **self.optimization_arguments)
RuntimeError: The following operation failed in the TorchScript interpreter.
Traceback of TorchScript (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/fastgraphcompute/extensions/binned_select_knn.py", line 91, in binned_select_knn

    # Use the C++ autograd kernel
    idx, dist = torch.ops.fastgraphcompute_custom_ops.binned_select_knn_autograd(
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
        coords, row_splits, K, direction, n_bins, max_bin_dims, torch_compatible_indices)
RuntimeError: Bin boundaries do not match row splits.
```

With this PR, CUDA device is explicitly set for each thread, fixing the race conditions leading to the failure.