### PR TITLE
Disable PlottingModules for multi-GPU training

### DIFF
--- a/src/djctools/module_extensions.py
+++ b/src/djctools/module_extensions.py
@@ -236,6 +236,8 @@ class PlottingModule(torch.nn.Module):
     """
     This layer is used to enable or disable plotting from within the model.
     It is meant as a base class from which to inherit, and should not be used directly.
+    The inhereting classes must not return anythin from the plot function, otherwise issues with model saving and
+    multi-GPU training can occur!!
     The logic works as follows:
       - If plotting is enabled, the forward method caches the data given to it while the model is executing. 
         It does not return anything, and it also does not start any plotting process.
@@ -323,13 +325,14 @@ class PlottingModule(torch.nn.Module):
         self._cache = []  # Clear the cache before plotting
         self.plot(data)
 
-    def plot(self, data):
+    def plot(self, data)-> None:
         """
         Override this method in the subclass to implement custom plotting logic.
+        !!The ploting functions must not return anything, otherwise model saving and mult-GPU training will not work correctly!!
         Args:
             data (list): Cached data to be plotted.
         """
-        raise NotImplementedError("The 'plot' method must be implemented in subclasses.")
+        raise NotImplementedError("The 'plot' method must be implemented in subclasses. It is not allowed to return anything.")
 
     def _join_plot_thread(self):
         """

--- a/src/djctools/training.py
+++ b/src/djctools/training.py
@@ -1,7 +1,7 @@
 # import as from djctools.training
 
 import torch
-from .module_extensions import flush_all_plotting
+from .module_extensions import flush_all_plotting, PlottingModule
 from .wandb_tools import wandb_wrapper
 import numpy as np
 import os
@@ -93,6 +93,7 @@ class Trainer:
             self.device_ids = device_ids if device_ids is not None else list(range(num_gpus))
             self.device = f'cuda:{self.device_ids[0]}'
             self.devices = [f'cuda:{device_id}' for device_id in self.device_ids]
+
         else:
             # Fall back to CPU if no GPU available or num_gpus is 1
             self.device = 'cpu'
@@ -115,9 +116,12 @@ class Trainer:
         
         print(f"Creating replicas using devices: {self.devices}")
 
+        if num_gpus > 1:
+            model = self.remove_plotting(model) #set all plotting modules to None to avoid deepcopy issues during multi-GPU training
         self.model_replicas = make_replicas(model, self.devices)
         self.optimizer = optimizer
         self.verbose_level = verbose_level
+
 
     def save_model(self, filepath):
         """
@@ -127,6 +131,7 @@ class Trainer:
             filepath (str): The path to the file where the model weights will be saved.
         """
         torch.save(self.model_replicas[0], filepath) #the first replica is always the master
+
 
     def load_model(self, filepath):
         """
@@ -282,3 +287,14 @@ class Trainer:
         use the wandb_wrapper.log() function instead.
         """
         pass
+
+    def remove_plotting(self, model):
+        """
+        Sets all plotting modules in model to None to avoid deepcopy issues during multi-GPU training.
+        """
+        print("Removing plotting modules for multi-GPU training...")
+        for name, module in model._modules.items():
+            if isinstance(module, PlottingModule):
+                model._modules[name] = None
+        
+        return model

--- a/src/djctools/training.py
+++ b/src/djctools/training.py
@@ -116,6 +116,7 @@ class Trainer:
         
         print(f"Creating replicas using devices: {self.devices}")
 
+        #TODO: fix plotting modules for multi-GPU training, currently just set to None
         if num_gpus > 1:
             model = self.remove_plotting(model) #set all plotting modules to None to avoid deepcopy issues during multi-GPU training
         self.model_replicas = make_replicas(model, self.devices)
@@ -291,6 +292,11 @@ class Trainer:
     def remove_plotting(self, model):
         """
         Sets all plotting modules in model to None to avoid deepcopy issues during multi-GPU training.
+        Plotting modules are not allowed to return anything from their plot function, otherwise this causes issues.
+
+        Args:
+        -----
+            model: the model from which to remove the plotting modules
         """
         print("Removing plotting modules for multi-GPU training...")
         for name, module in model._modules.items():


### PR DESCRIPTION
Sets classes inheriting from PlottingModule during model training to None to avoid deepcopy issues in multi-GPU training.
